### PR TITLE
Use a production env template for deploy builds

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -1,0 +1,112 @@
+# =============================================================================
+# CubeFSRS SolidJS PWA - Production Environment Template
+# =============================================================================
+
+# Use of .env and/or .env.local files are strongly discouraged for local
+# development and/or production configuration. To build or deploy production,
+# keep the real values in 1Password and use `op run --env-file=".env.prod.template"`
+# so the build process receives production-safe values without storing them in
+# the repository.
+
+
+# -----------------------------------------------------------------------------
+# Supabase Configuration (REQUIRED for new SolidJS PWA)
+# -----------------------------------------------------------------------------
+# Get these from: https://app.supabase.com/project/_/settings/api
+
+# Supabase Project URL
+# Example: https://abcdefghijklmnop.supabase.co
+VITE_SUPABASE_URL="op://rhizome/shared-local/Supabase/VITE_SUPABASE_URL"
+
+# Supabase Anonymous Key (public, safe for client-side use)
+# This key is used for client-side auth and queries
+VITE_SUPABASE_ANON_KEY="op://rhizome/shared-local/Supabase/VITE_SUPABASE_ANON_KEY"
+
+# Supabase Service Role Key (KEEP SECRET - server-side only)
+# Only needed for admin operations, data migration, or server-side scripts
+# NEVER expose this in client-side code
+SUPABASE_SERVICE_ROLE_KEY="op://rhizome/shared-local/Supabase/SUPABASE_SERVICE_ROLE_KEY"
+
+# PostgreSQL Connection String for Drizzle migrations
+# Get from: https://app.supabase.com/project/_/settings/database
+# Format: postgresql://postgres:[YOUR-PASSWORD]@db.[PROJECT-REF].supabase.co:5432/postgres
+DATABASE_URL="op://rhizome/shared-local/Supabase/DATABASE_URL_REMOTE"
+
+# -----------------------------------------------------------------------------
+# OAuth Provider Credentials (OPTIONAL - for social login)
+# -----------------------------------------------------------------------------
+# Google OAuth (for "Sign in with Google")
+# Get from: https://console.cloud.google.com/apis/credentials
+# Create OAuth 2.0 Client ID and configure authorized redirect URIs
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID="op://rhizome/shared-local/Supabase/SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID"
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET="op://rhizome/shared-local/Supabase/SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET"
+
+# GitHub OAuth (for "Sign in with GitHub")
+# Get from: https://github.com/settings/developers
+# Create a new OAuth App and configure callback URL
+SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID="op://rhizome/shared-local/Supabase/SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID"
+SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET="op://rhizome/shared-local/Supabase/SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET"
+
+# -----------------------------------------------------------------------------
+# Production Build Settings
+# -----------------------------------------------------------------------------
+PYTHONPATH=.
+
+# Repository name
+GITHUB_REPO=cubefsrs
+
+# Sync Worker URL for production builds.
+# Use a production-specific 1Password field so deployed bundles never point to
+# a local worker URL such as http://localhost:8797.
+VITE_WORKER_URL="op://rhizome/shared-local/Vite/VITE_WORKER_URL_PRODUCTION"
+
+# Enable debug logging for sync operations (default: false)
+# Set to 'true' to see detailed sync logs in console
+# VITE_SYNC_DEBUG=true
+
+# Enable sync diagnostics summary logs (default: false)
+# Set to 'true' to log compact per-sync summaries such as:
+#   [SyncDiag] type=INITIAL|INCREMENTAL pushed=.. pulled=.. pages=.. durationMs=..
+#   [SyncDiag] topTables=table:count,...
+#
+# Note: to also see worker-side diagnostic lines in the browser console, the
+# worker must be configured with SYNC_DIAGNOSTICS=true (see worker/wrangler.toml).
+# VITE_SYNC_DIAGNOSTICS=true
+
+# Disable automatic sync (default: false)
+# Set to 'true' to prevent sync worker from starting
+# Useful for testing local seed data or offline development
+# VITE_DISABLE_SYNC=true
+
+# Enable Supabase Realtime live sync (default: false)
+# Set to 'true' to enable websocket-based real-time synchronization
+# Note: Requires Realtime to be enabled in your Supabase project settings
+# VITE_REALTIME_ENABLED=true
+
+# Enable Workbox (service worker) debug logs (default: false)
+# Set to 'true' to see "workbox Router is responding to..." messages
+# Useful for debugging PWA caching behavior
+# VITE_WORKBOX_DEBUG=true
+
+# -----------------------------------------------------------------------------
+# AI Practice Assistant (Google Gemini)
+# -----------------------------------------------------------------------------
+# Get your free API key from: https://aistudio.google.com/app/apikey
+# This enables the conversational AI assistant for natural language queries
+# IMPORTANT: For production, set this in Supabase Secrets (not in .env):
+#   supabase secrets set GEMINI_API_KEY=your_key_here
+# For local development with Supabase Functions:
+#   supabase secrets set GEMINI_API_KEY=your_key --env-file .env.local
+GEMINI_API_KEY="op://rhizome/shared-local/Gemini/GEMINI_API_KEY"
+# Optional model override for Edge Function (default in code: gemini-2.0-flash)
+# GEMINI_MODEL=gemini-2.0-flash
+
+
+# -----------------------------------------------------------------------------
+# Test Stuff
+# -----------------------------------------------------------------------------
+
+# The ALICE_TEST_PASSWORD is shared between all the test users, at least
+# for now. It doesn't really have to be a secret, but since it's a password
+# to a user in supabase, it's best to keep it not exposed.
+ALICE_TEST_PASSWORD="op://rhizome/shared-local/Test/ALICE_TEST_PASSWORD"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 # Environment secrets (cubefsrs_ci_env): OP_SERVICE_ACCOUNT_TOKEN, CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, SUPABASE_JWT_SECRET, VITE_WORKER_URL
-# All Supabase/app secrets are injected at runtime via `op run --env-file=".env.local.template"` using the OP_SERVICE_ACCOUNT_TOKEN.
+# Pages builds inject app secrets via `op run --env-file=".env.prod.template"`; local scripts continue to use `.env.local.template`.
 # yamllint disable rule:line-length
 
 name: CI - Tests
@@ -425,8 +425,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Build uses `op run` wrappers in package.json to inject VITE_ secrets
-      # from the rhizome vault at build time.
+      # Build uses the production env template so deployed bundles do not
+      # inherit local worker URLs from the local dev template.
       - name: Build Application
         run: npm run build
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Build and preview both flow through package.json scripts, which in turn
-      # use `op run --env-file=".env.local.template"` to inject runtime config.
+      # Build flows through the production template so the analyzed bundle
+      # matches deployed settings instead of local worker configuration.
       - name: Build Application
         run: npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5053,7 +5053,7 @@
 		},
 		"node_modules/oosync": {
 			"version": "0.1.0",
-			"resolved": "git+ssh://git@github.com/sboagy/oosync.git#0bd3d058548ac29d774e56c35167da2726184114",
+			"resolved": "git+ssh://git@github.com/sboagy/oosync.git#aceff8724d79e6e4eee44a74e984c0270f3493d4",
 			"dev": true,
 			"dependencies": {
 				"drizzle-orm": "^0.45.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 	"scripts": {
 		"dev": "FORCE_COLOR=1 op run --env-file=\".env.local.template\" -- vite",
 		"dev:test": "FORCE_COLOR=1 op run --env-file=\".env.local.template\" -- vite --mode test",
-		"build": "FORCE_COLOR=1 op run --env-file=\".env.local.template\" -- vite build",
+		"build": "npm run build:production",
+		"build:production": "FORCE_COLOR=1 op run --env-file=\".env.prod.template\" -- vite build",
 		"build:preview-local": "FORCE_COLOR=1 op run --env-file=\".env.local.template\" -- vite build",
 		"preview": "FORCE_COLOR=1 op run --env-file=\".env.local.template\" -- vite preview",
 		"preview:local": "op run --env-file=\".env.local.template\" -- vite preview --strictPort --port 4174",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1414,7 +1414,7 @@
 		},
 		"node_modules/oosync": {
 			"version": "0.1.0",
-			"resolved": "git+ssh://git@github.com/sboagy/oosync.git#0bd3d058548ac29d774e56c35167da2726184114",
+			"resolved": "git+ssh://git@github.com/sboagy/oosync.git#aceff8724d79e6e4eee44a74e984c0270f3493d4",
 			"dependencies": {
 				"drizzle-orm": "^0.45.1",
 				"jose": "^6.1.3",

--- a/worker/package.json
+++ b/worker/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"deploy": "FORCE_COLOR=1 op run --env-file=\"../.env.local.template\" -- wrangler deploy",
+		"deploy": "FORCE_COLOR=1 op run --env-file=\"../.env.prod.template\" -- wrangler deploy",
 		"dev": "FORCE_COLOR=1 op run --env-file=\"../.env.local.template\" -- node ./scripts/run-wrangler-dev.mjs",
 		"dev:local": "WRANGLER_SEND_METRICS=false DO_NOT_TRACK=1 FORCE_COLOR=1 op run --env-file=\"../.env.local.template\" -- node ./scripts/run-wrangler-dev.mjs --local",
 		"start": "FORCE_COLOR=1 op run --env-file=\"../.env.local.template\" -- node ./scripts/run-wrangler-dev.mjs"


### PR DESCRIPTION
## Summary
- add a dedicated `.env.prod.template` for production builds and deploys
- switch the app build and worker deploy scripts to use the production template
- update CI and Lighthouse workflow comments so they reflect the production env path

## Validation
- `npm run typecheck`

## Companion
- depends on the oosync startup sync fix in https://github.com/sboagy/oosync/pull/7
