### PR TITLE
Fix production Supabase env configuration

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -16,11 +16,13 @@
 
 # Supabase Project URL
 # Example: https://abcdefghijklmnop.supabase.co
-VITE_SUPABASE_URL="op://rhizome/shared-local/Supabase/VITE_SUPABASE_URL"
+VITE_SUPABASE_URL="op://rhizome/shared-local/Supabase/SUPABASE_URL_PRODUCTION"
 
 # Supabase Anonymous Key (public, safe for client-side use)
 # This key is used for client-side auth and queries
 VITE_SUPABASE_ANON_KEY="op://rhizome/shared-local/Supabase/VITE_SUPABASE_ANON_KEY"
+
+SUPABASE_URL="op://rhizome/shared-local/Supabase/SUPABASE_URL_PRODUCTION"
 
 # Supabase Service Role Key (KEEP SECRET - server-side only)
 # Only needed for admin operations, data migration, or server-side scripts
@@ -110,3 +112,9 @@ GEMINI_API_KEY="op://rhizome/shared-local/Gemini/GEMINI_API_KEY"
 # for now. It doesn't really have to be a secret, but since it's a password
 # to a user in supabase, it's best to keep it not exposed.
 ALICE_TEST_PASSWORD="op://rhizome/shared-local/Test/ALICE_TEST_PASSWORD"
+
+CLOUDFLARE_ACCOUNT_ID="op://rhizome/shared-local/Cloudflare/CLOUDFLARE_ACCOUNT_ID"
+
+CLOUDFLARE_API_TOKEN="op://rhizome/shared-local/Cloudflare/CLOUDFLARE_API_TOKEN"
+
+SUPABASE_JWT_SECRET="op://rhizome/shared-local/Supabase/SUPABASE_JWT_SECRET_PRODUCTION"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -14,8 +14,8 @@ id = "e7f5143597204a649319d5312b3355f3"
 localConnectionString = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 
 [vars]
-# Production/default binding. Local npm scripts override SUPABASE_URL with
-# `wrangler dev --var` so the worker matches the 1Password-backed local app env.
+# Production worker runtime config. Keep this aligned with the production
+# Supabase project used by the app build env.
 SUPABASE_URL = "https://pjxuonglsvouttihjven.supabase.co"
 # SUPABASE_URL = "http://127.0.0.1:54321"
 # SUPABASE_JWT_SECRET should be set via `wrangler secret put SUPABASE_JWT_SECRET`


### PR DESCRIPTION
## Summary
- point the production app build at the production Supabase URL from 1Password
- keep the worker deploy flow simple with static production SUPABASE_URL in wrangler.toml
- add Cloudflare deploy credentials and production JWT secret placeholders to the production env template

## Validation
- verified worker config files are error-free
- confirmed the worker deploy path stays aligned with the simpler TuneTrees pattern