### PR TITLE
Refactor practice tracking flow and harden practice readiness

### DIFF
--- a/e2e/page-objects/CubeFSRSPage.ts
+++ b/e2e/page-objects/CubeFSRSPage.ts
@@ -112,6 +112,14 @@ export class CubeFSRSPage {
 	}
 
 	/**
+	 * Practice content that indicates the main view has finished rendering.
+	 * This is either the empty-state banner or an algorithm row when a due card exists.
+	 */
+	get practiceContent(): Locator {
+		return this.emptyStateMessage.or(this.algorithmText).first();
+	}
+
+	/**
 	 * The algorithm text span in PracticeView.
 	 * Contains move notation like `R U R' U'`.
 	 */
@@ -291,6 +299,14 @@ export class CubeFSRSPage {
 		).toBeVisible({
 			timeout: 10_000,
 		});
+	}
+
+	/** Wait for the Practice view to render either an empty state or an algorithm. */
+	async waitForPracticeContent(timeout = 10_000): Promise<void> {
+		await expect(
+			this.page.getByRole("heading", { name: "Practice" }),
+		).toBeVisible({ timeout });
+		await expect(this.practiceContent).toBeVisible({ timeout });
 	}
 
 	/**

--- a/e2e/tests/offline-001-device-mode.spec.ts
+++ b/e2e/tests/offline-001-device-mode.spec.ts
@@ -35,13 +35,18 @@ test.describe("offline-001: device-only mode", () => {
 		await expect(page).toHaveURL(/\/$/, { timeout: 15_000 });
 		await expect(cfPage.practiceLink).toBeVisible({ timeout: 10_000 });
 
+		// Wait for the practice view to finish rendering before taking the
+		// browser offline. Anonymous users usually land in the empty state,
+		// but seeded local data can also show an algorithm card.
+		await cfPage.waitForPracticeContent();
+
 		// Simulate going offline.
 		await goOffline(page);
 
 		// App should still render the practice view after going offline.
 		// The empty-state or an algorithm display should be visible (depends on
-		// whether any FSRS cards were seeded — anonymous users start with none).
-		await expect(cfPage.emptyStateMessage).toBeVisible({ timeout: 5_000 });
+		// whether any FSRS cards were seeded — anonymous users usually start with none).
+		await cfPage.waitForPracticeContent();
 
 		// Restore network before test cleanup.
 		await goOnline(page);

--- a/plans/cf-refactor-cube.md
+++ b/plans/cf-refactor-cube.md
@@ -1,0 +1,475 @@
+# Plan: Cube Visualization, Mapping & Algorithm Tracking Refactor
+
+**Issue:** [#6 — Error detection for bad turns often fails](https://github.com/sboagy/cubefsrs/issues/6)
+**Branch:** `cf-cube-refactor`
+**Status:** In planning
+
+---
+
+## 0. Purpose of This Document
+
+Issue #6 contains an abstract plan for a "Fixed-Grip Translation Layer" to support
+Yellow-Up drilling. This document maps that abstract plan to the **actual codebase**,
+identifies bugs and gaps, and proposes concrete, ordered steps to reach a working
+state. Clarifying questions were answered by the owner and are recorded in [§7](#7-clarifying-questions-and-answers).
+
+---
+
+## 1. Current State Assessment
+
+Most of the infrastructure described in the issue is **already implemented**. The
+table below shows what exists, so no one inadvertently recreates it.
+
+| Component | File | Status |
+|---|---|---|
+| z2 move-translation map (`mapTokenByZ2`) | `src/lib/orientationMap.ts` | ✅ Complete, unit-tested |
+| Orientation mode signal + localStorage persistence | `src/stores/orientation.ts` | ✅ Complete |
+| Orientation UI toggle (Yellow-Up / White-Up) | `src/views/OptionsView.tsx` | ✅ Complete |
+| Visual z2 flip for TwistyPlayer (`experimentalSetupAlg`) | `src/components/practice/CubeViewer.tsx` | ✅ Complete |
+| z2 applied to `experimentalAddMove` for live hardware | `src/components/practice/CubeViewer.tsx` | ✅ Complete |
+| z2 translation inside `ingestMove` (tracking) | `src/stores/tracking.ts` | ✅ Exists — **but has a double-application bug (§2)** |
+| Rotation-candidate calibration inside `ingestMove` | `src/stores/tracking.ts` | ✅ Exists — needs verification after §2 fix |
+| `ingestMove` orientation parameter (replaces `window._orientationMode`) | `src/stores/tracking.ts` | ❌ Not yet — to be added (§2-refactor) |
+| Rotation auto-advance for mid-algorithm `x`/`y`/`z` tokens | `src/stores/tracking.ts` | ❌ Not yet (§3) |
+| AUF prefix wired to `CubeViewer` and `setAlgorithm` | `src/views/PracticeView.tsx` | ❌ Incomplete (§5) |
+| Unit tests: `mapTokenByZ2` | `tests/lib/orientationMap.test.ts` | ✅ Complete |
+| Unit tests: `ingestMove` / tracking store | (none) | ❌ Missing |
+
+---
+
+## 2. Root Bug: Double-Translation in the Move Pipeline
+
+### 2.1 Diagnosis
+
+The primary bug causing error detection to fail for Yellow-Up is a **double application
+of the z2 orientation map** before any move is evaluated against the algorithm.
+
+**Pipeline for a physical Yellow-Up turn (e.g., physical top-face CW → hardware reports `D`):**
+
+```
+Hardware emits "D"
+  │
+  ▼
+device store: lastMove = "D", lastMoveAt = <timestamp>
+  │
+  ├─► CubeViewer.tsx effect:
+  │     raw "D" → mapTokenByZ2("D") = "U"
+  │     TwistyPlayer.experimentalAddMove("U")      ← correct: visual shows U turn
+  │
+  └─► PracticeView.tsx effect:                      ← BUG STARTS HERE
+        logical = mapTokenByZ2("D") = "U"
+        ingestMove("U")
+          │
+          └─ inside ingestMove (tracking.ts):
+               reads window._orientationMode = "yellow-up"
+               logical = mapTokenByZ2("U") = "D"  ← second application cancels first!
+               compare "D" against algorithm's expected "U" → MISMATCH → false error
+```
+
+Since `mapTokenByZ2` is its own inverse (z2 ∘ z2 = identity for all face moves),
+applying it twice cancels out. The tracking logic effectively receives the raw hardware
+move, not the logical yellow-up move — so it can never match an OLL/PLL algorithm
+written in standard white-up notation.
+
+### 2.2 Fix — Part A: Remove pre-translation; Part B: Replace global with explicit parameter
+
+These two changes are done together since they touch the same call site.
+
+**Part A — Remove the pre-translation in `PracticeView.tsx`.** Pass the raw device
+move to `ingestMove`. The tracking store should receive the raw hardware move and
+translate it once internally.
+
+**Part B — Replace `window._orientationMode` global bridge.** Rather than routing
+orientation state through a mutable `window` global, add an explicit `orientation`
+parameter to `ingestMove`. `PracticeView` passes the reactive `orientationMode()`
+value. This eliminates the code smell while also making the fix cleaner.
+
+**File:** `src/stores/tracking.ts`
+
+```diff
+-export function ingestMove(deviceMove: string) {
++export function ingestMove(deviceMove: string, orientation: import("@/stores/orientation").OrientationMode = "white-up") {
+   ...
+-  const orientationMode = window._orientationMode || "white-up";
+-  if (orientationMode === "yellow-up") logical = mapTokenByZ2(logical);
++  if (orientation === "yellow-up") logical = mapTokenByZ2(logical);
+   ...
+ }
+```
+
+All occurrences of `window._orientationMode` inside `tracking.ts` are replaced by
+the local `orientation` parameter. The `declare global { interface Window { _orientationMode? } }`
+declaration and the write in `src/stores/orientation.ts` can both be removed once
+no other call site uses the global.
+
+**File:** `src/views/PracticeView.tsx`
+
+```diff
+ createEffect(() => {
+     const moveAt = device.lastMoveAt;
+     const mv = untrack(() => device.lastMove);
+     if (moveAt == null) return;
+     if (!mv) return;
+     untrack(() => {
+-        const logical =
+-            orientationMode() === "yellow-up" ? mapTokenByZ2(mv.trim()) : mv.trim();
+-        ingestMove(logical);
++        // Pass the raw device move and orientation. tracking.ts applies the
++        // z2 map internally so it is not applied twice (z2 ∘ z2 = identity = bug).
++        ingestMove(mv.trim(), orientationMode());
+     });
+ });
+```
+
+After this change, the `mapTokenByZ2` import can be removed from `PracticeView.tsx`
+(but `orientationMode` is still used — keep that import).
+
+### 2.3 Verification
+
+After the fix, the expected pipeline becomes:
+
+```
+Hardware emits "D"
+  │
+  ├─► CubeViewer: mapTokenByZ2("D") = "U" → TwistyPlayer.experimentalAddMove("U")  ✅
+  └─► PracticeView: ingestMove("D", "yellow-up")
+        └─ tracking.ts: mapTokenByZ2("D") = "U", compare "U" vs expected "U"       ✅
+```
+
+### 2.4 `_didEarlyCalibration` reset
+
+The module-level `_didEarlyCalibration` flag is never reset after the first algorithm
+loads in a session. This means if a user changes their grip orientation or physically
+moves the cube between algorithms, the calibration phase is skipped for all subsequent
+algorithms. **Decision (Q3 answer):** reset it in `setAlgorithm`.
+
+```diff
+ export function setAlgorithm(raw: string) {
+   ...
++  _didEarlyCalibration = false;
+   ...
+ }
+```
+
+---
+
+## 3. Rotation Tokens in Algorithms
+
+### 3.1 Problem Description
+
+Some OLL/PLL algorithms include whole-cube rotation tokens (`x`, `y`, `z`). For
+example: `R U R' y R' U R U' R'`. When the user physically rotates the cube mid-solve,
+most GAN Bluetooth cubes (without gyroscopes) **do not emit a rotation event**. The
+hardware only reports face moves. As a result:
+
+- The kpuzzle-based pattern state correctly advances through the rotation in its
+  internal representation.
+- The user's next physical face move is relative to the new physical orientation, but
+  the device still reports it in the original hardware face encoding.
+- Unless the `eventTransform` auto-calibration detects the orientation change, the move
+  will be flagged as an error.
+
+### 3.2 Existing Mitigation
+
+`ingestMove` already has a multi-pass rotation-candidate loop (`rotationCandidates()`)
+that tries every combination of x/y/z rotations to find one that makes the move match.
+This fires:
+- On the first move (`_didEarlyCalibration` guard)
+- After a miss when `eventTransform` is not yet set
+- As a "rotation refinement" when `eventTransform` is set and the algorithm advances
+
+This mechanism **may correctly handle most mid-algorithm rotations** if the calibration
+fires at the right time. The question is whether it reliably fires on the move
+immediately following a rotation token.
+
+### 3.3 Implementation: Auto-Skip Rotation Tokens (Option A — confirmed)
+
+**Decision (Q1 answer):** Implement Option A. Critical OLL/PLL algorithms do contain
+mid-algorithm rotation tokens and the auto-skip approach is the correct solution.
+
+Add a helper `advancePastRotations()` that silently advances `currentMoveIndex` past
+any rotation token (`x`, `y`, `z`, with any suffix) that would otherwise wait for a
+hardware event that never comes. The physical rotation the user performs after the
+token changes their hardware→logical face mapping, which is already detected by the
+existing `eventTransform` calibration on the next face move.
+
+```typescript
+// In tracking.ts — call after each successful move acceptance and in setAlgorithm
+function advancePastRotations() {
+  while (true) {
+    const next = tracking.userAlg[tracking.currentMoveIndex + 1];
+    if (!next) break;
+    const clean = next.replace(/[()]/g, "");
+    if (!/^[xyz](?:[2'])?$/i.test(clean)) break;
+    // It's a rotation token — advance without hardware input.
+    // _progressPatternRaw has already been computed for this index during initPatterns.
+    const nextIndex = tracking.currentMoveIndex + 1;
+    _progressPatternRaw = _patternStates[nextIndex] ?? _progressPatternRaw;
+    setTracking("currentMoveIndex", nextIndex);
+    // Reset early calibration so the next face move re-probes orientation.
+    _didEarlyCalibration = false;
+  }
+}
+```
+
+`advancePastRotations()` is called:
+1. At the end of every successful single/slice/wide/double acceptance block in `ingestMove`
+2. In `setAlgorithm` after `recomputeDisplay()` (in case the algorithm starts with a rotation token)
+3. In `forceReady()` and `ensureImmediateReady()` after pattern init completes
+
+**Note on `_didEarlyCalibration`:** Resetting it inside `advancePastRotations()` is
+intentional — after the user physically rotates the cube, the next face move will
+have a different hardware→logical mapping and the calibration probe needs to re-run.
+
+---
+
+## 4. Required Test Coverage
+
+### 4.1 `tests/stores/tracking.test.ts` — New File
+
+The tracking store has the most complex logic in the codebase and has **zero unit
+tests**. This is the highest-risk gap. The following test scenarios should be covered:
+
+| Scenario | What to verify |
+|---|---|
+| **Happy path — single move** | `ingestMove("R")` with alg `"R U R'"` → `currentMoveIndex` becomes 0 |
+| **Happy path — full sequence** | Step through all moves of a short alg → all tokens green, `currentMoveIndex` reaches end |
+| **Yellow-up: D → U acceptance** | `ingestMove("D", "yellow-up")` on alg `"U ..."` → accepted |
+| **Yellow-up: no double-cancel** | `ingestMove("D", "yellow-up")` (raw move, correct orientation) accepts as `"U"`; `ingestMove("U", "yellow-up")` on same alg → rejected (proves no double-cancel) |
+| **Wrong move → error** | `ingestMove("L")` when next expected is `"R"` → `badAlg` non-empty |
+| **Undo (inverse)** | After wrong `"L"`, send `"L'"` → `badAlg` clears |
+| **Slice composite (M)** | Two-part M slice via `"R"` + `"L'"` sequence → advance to next token |
+| **Double turn (U2 = U + U)** | Two consecutive `"U"` quarter turns → advance past `"U2"` token |
+| **Rotation token — auto-advance** | Alg `"R y R'"` → after `"R"` accepted, rotation auto-advances, `"R"` (from new POV) accepted next |
+| **`setAlgorithm` resets state** | After partial progress, `setAlgorithm(newAlg)` → `currentMoveIndex = -1`, `badAlg = []` |
+| **`resetTracking` resets state** | Mid-alg `resetTracking()` → `currentMoveIndex = -1`, `badAlg = []` |
+
+Mock requirements for `tracking.test.ts` (follow the pattern in `fsrs.test.ts`):
+
+```typescript
+vi.mock("cubing/alg", () => ({ Alg: { fromString: () => ({ invert: () => ({toString: () => ""}) }) } }));
+vi.mock("cubing/puzzles", () => ({ cube3x3x3: { kpuzzle: () => Promise.resolve({ defaultPattern: () => new SeqPatternStub() }) } }));
+vi.mock("@/stores/algs", () => ({ algs: { options: { randomAUF: false } } }));
+```
+
+The `SeqPattern` class (already in `tracking.ts` as a module-level class) can be used
+as the pattern stub for tests since it is already exported-compatible.
+
+**Note on `_didEarlyCalibration`:** This module variable is a shared mutable singleton.
+Because `setAlgorithm` will now reset it (§2.4), tests simply call `setAlgorithm`
+before each scenario to get a clean slate. No separate reset export is needed.
+
+### 4.2 `tests/lib/orientationMap.test.ts` — Already Exists
+
+Current coverage is comprehensive. No additions needed for this refactor unless new
+orientation modes are added (see [Q2](#q2-additional-orientation-modes)).
+
+---
+
+## 5. AUF Prefix Wiring
+
+### 5.1 Current State
+
+The `_auf` signal in `PracticeView.tsx` is populated with a random AUF string (`""`,
+`"U"`, `"U2"`, or `"U'"`) when the user clicks Train with `randomAUF` enabled, but
+it is **never applied**: `CubeViewer` receives `baseAlg()` and `setAlgorithm` is called
+with `baseAlg()`, so the AUF is a no-op.
+
+### 5.2 Fix
+
+Introduce an `aufAlg()` derived memo that prepends the AUF prefix to `baseAlg()` when
+`randomAUF` is enabled and `_auf()` is non-empty. Use `aufAlg()` everywhere the
+algorithm is shown or tracked.
+
+```typescript
+// In PracticeView.tsx — replace the baseAlg usages for tracking/viewer
+const aufAlg = createMemo(() => {
+  const auf = _auf();
+  const base = baseAlg();
+  if (!auf || !algs.options.randomAUF) return base;
+  return `${auf} ${base}`.trim();
+});
+```
+
+Changes:
+1. `CubeViewer alg={aufAlg()}` (was `baseAlg()`)
+2. In the `setAlgorithm` effect, track `aufAlg()` instead of `baseAlg()` and compare
+   against `tracking.rawAlg` accordingly.
+3. The `trainNonce` bump on Train should still force a visual reset even when the AUF
+   string does not change between clicks (same nonce logic as before).
+
+### 5.3 Orientation Interaction
+
+The AUF string (`U`, `U2`, `U'`) is written in **logical (standard) notation**.
+In Yellow-Up mode the user physically performs a top-face turn; the hardware reports
+`D`; `ingestMove` translates `D` → `U` before comparing against the AUF `U`. No
+special orientation treatment of the AUF string is required.
+
+### 5.4 Required Test Scenario
+
+Add to `tracking.test.ts`:
+
+| Scenario | What to verify |
+|---|---|
+| **AUF prefix tracked** | `setAlgorithm("U R U R'")` → `ingestMove("U", "white-up")` advances past the AUF `U` |
+| **AUF prefix tracked — yellow-up** | `setAlgorithm("U R U R'")` → `ingestMove("D", "yellow-up")` advances past the AUF `U` |
+
+---
+
+## 6. Scope Boundary: What NOT to Change
+
+The following items are **out of scope** for this refactor:
+
+| Item | Rationale |
+|---|---|
+| `CaseThumb.tsx` orientation | Thumbnails in the library view intentionally show the standard algorithm representation (white-up). They do not receive live device moves. |
+| FSRS scheduling logic | No changes needed for this issue. |
+| Supabase / oosync sync layer | No changes needed for this issue. |
+| `experimentalSetupAlg` in `CubeViewer.tsx` | The `z2` setup for the visual flip is correct and complete. |
+| Color-neutral orientation mode | Explicitly future work (Q2 answer). |
+
+---
+
+## 7. Implementation Order
+
+### Step 1 — Fix double-translation + replace `window._orientationMode` _(Priority: Critical)_
+- Edit `src/stores/tracking.ts`: add `orientation` parameter to `ingestMove`, remove
+  all reads of `window._orientationMode` and the `declare global` block.
+- Edit `src/views/PracticeView.tsx`: remove the pre-translation logic; pass `orientationMode()`
+  as the second argument to `ingestMove`; remove the now-unused `mapTokenByZ2` import.
+- Edit `src/stores/orientation.ts`: remove the `window._orientationMode = ...` write
+  if no other consumer remains.
+- Manual smoke-test: Yellow-Up selected, perform a physical top-face-clockwise turn;
+  verify TwistyPlayer shows a `U` turn and tracking advances.
+
+### Step 2 — Reset `_didEarlyCalibration` in `setAlgorithm` _(Priority: High)_
+- Edit `src/stores/tracking.ts` per §2.4.
+- One-line change.
+
+### Step 3 — Implement rotation auto-advance _(Priority: High)_
+- Add `advancePastRotations()` to `tracking.ts` per §3.3.
+- Call it from every successful acceptance branch in `ingestMove`, from `setAlgorithm`,
+  from `forceReady`, and from `ensureImmediateReady`.
+
+### Step 4 — Implement AUF prefix wiring _(Priority: Medium)_
+- Add `aufAlg()` memo to `PracticeView.tsx` per §5.2.
+- Pass `aufAlg()` to `CubeViewer` and use it in the `setAlgorithm` effect.
+
+### Step 5 — Add tracking store unit tests _(Priority: High — write alongside Steps 1–4)_
+- Create `tests/stores/tracking.test.ts` covering the scenarios in §4.1 and §5.4.
+- The Yellow-Up regression test guards against reintroducing the double-translation bug.
+
+### Step 6 — Run full test suite and typecheck _(Priority: Required before merge)_
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+```
+
+All must pass with zero new errors.
+
+---
+
+## 8. Clarifying Questions and Answers
+
+### Q1: Rotation auto-skip
+
+When an algorithm contains a whole-cube rotation token (`x`, `y`, `z`) and the user is
+drilling without a gyroscope-equipped cube, what should happen?
+
+**Option A — Auto-skip:** The app silently advances past the rotation token. The user
+physically rotates the cube and the next face move is evaluated relative to the new
+orientation (via the existing `eventTransform` calibration).
+
+**Option B — Require physical rotation + calibration:** The app does not auto-advance.
+The user must physically rotate, and the `eventTransform` mechanism detects the change
+from the discrepancy between the next expected move and what the hardware reports. This
+is the current implicit behavior.
+
+**Option C — Ignore rotations in algorithms entirely:** Algorithms that include rotation
+tokens are re-written or flagged to avoid them, so the question is moot in practice.
+
+**Preference / use cases to consider:** Which algorithm categories currently in use
+contain rotation tokens? Do any critical OLL/PLL cases require mid-algorithm rotations?
+
+> **Answer:**
+
+> Do any critical OLL/PLL cases require mid-algorithm rotations?
+
+Yes.
+
+I think do your best with Option A.
+
+---
+
+### Q2: Additional orientation modes
+
+The abstract plan mentions `CubeOrientation = 'white-up' | 'yellow-up'` but also notes
+it can "expand to color-neutral later." Is color-neutral drilling within scope for this
+iteration or strictly future work?
+
+> **Answer:**
+
+Strictly future work.  I will be happy if both white-up and yellow-up work correctly, at least for now.
+
+---
+
+### Q3: `_didEarlyCalibration` singleton
+
+The module-level `_didEarlyCalibration` flag in `tracking.ts` is reset to `false` only
+on module load. In practice, once calibration fires on the first algorithm, it never
+re-runs for subsequent algorithms in the same session, even if the user changes their
+grip. Is this intentional? Should it reset when `setAlgorithm` is called?
+
+> **Answer:**
+
+I don't really know the answer for this.  I assume the reset when `setAlgorithm` is called is correct.  But just do the right thing. 
+
+---
+
+### Q4: Default orientation
+
+`src/stores/orientation.ts` defaults to `"yellow-up"` when no preference is stored:
+
+```typescript
+const stored = safeGet<OrientationMode>("cubefsrs.orientationMode", "yellow-up");
+```
+
+Is this intentional for new users? Or should the default be `"white-up"` (the WCA
+standard)?
+
+> **Answer:**
+
+I think keep the default as yellow-up.  I might change my mind at some point, I guess.  But I think white-up 
+is just stupid.
+
+---
+
+### Q5: Handling algorithms with AUF (pre-move U turns)
+
+The practice view has a `randomAUF` option. When AUF is enabled, a random `U` move
+prefix is added. In Yellow-Up mode, `U` maps to `D`. Is the AUF logic already
+orientation-aware, or does it also need to be patched?
+
+Looking at `PracticeView.tsx`: the `_auf` signal stores the AUF string but I did not
+find where it is applied to the tracking algorithm or to `CubeViewer`. This may be a
+separate incomplete feature.
+
+> **Answer:**
+
+I'm pretty sure it's an incomplete feature.  See if you can make it work correctly?
+
+---
+
+## 9. Deferred Items (Future Issues)
+
+These were observed during the codebase review. They are explicitly out of scope for
+this refactor:
+
+- **`CaseThumb.tsx` does not react to `orientationMode`** — Thumbnails in the library
+  always show white-up. For Yellow-Up users this means the thumbnail shows the solved
+  state from white-up perspective. Low impact since the main practice viewer is correct.
+
+- **Color-neutral orientation mode** — The type `OrientationMode = 'white-up' | 'yellow-up'`
+  is designed to expand, but color-neutral support is strictly future work (Q2 answer).

--- a/src/stores/orientation.ts
+++ b/src/stores/orientation.ts
@@ -15,11 +15,4 @@ export { orientationMode };
 export function setOrientationMode(mode: OrientationMode) {
 	safeSet("cubefsrs.orientationMode", mode);
 	setOrientationModeSignal(mode);
-	// Expose to non-reactive service layer used by tracking
-	window._orientationMode = mode;
-}
-
-// Initialise global on load
-if (typeof window !== "undefined") {
-	window._orientationMode = stored;
 }

--- a/src/stores/practice.ts
+++ b/src/stores/practice.ts
@@ -147,12 +147,9 @@ export function stopPractice() {
 	setPractice("startAt", null);
 }
 
-export function restartRun() {
-	if (!practice.running) {
-		startPractice();
-		return;
-	}
-	setPractice("startAt", Date.now());
+export function resetRun() {
+	setPractice("running", false);
+	setPractice("startAt", null);
 }
 
 export function cycleVisibility() {

--- a/src/stores/tracking.ts
+++ b/src/stores/tracking.ts
@@ -342,7 +342,10 @@ export function ingestMove(move: string) {
 			return;
 		}
 	}
-	const next = tracking.userAlg[tracking.currentMoveIndex + 1];
+	const hadNoAcceptedMoves = tracking.acceptedDeviceMoves.length === 0;
+	advancePastRotations();
+	const nextIndex = tracking.currentMoveIndex + 1;
+	const next = tracking.userAlg[nextIndex];
 	if (!next) {
 		debug("skip:no-next", {
 			idx: tracking.currentMoveIndex,
@@ -371,17 +374,16 @@ export function ingestMove(move: string) {
 		debug("skip:no-basePattern");
 		return;
 	}
-	const nextIndex = tracking.currentMoveIndex + 1;
 	const expectedPattern = _patternStates[nextIndex];
 	const expectNorm = norm(next);
 
 	// Early rotation calibration
 	if (
-		tracking.currentMoveIndex === -1 &&
+		hadNoAcceptedMoves &&
 		!tracking.eventTransform &&
 		!_didEarlyCalibration
 	) {
-		const expectedTok = tracking.canonical[0];
+		const expectedTok = tracking.canonical[nextIndex];
 		if (expectedTok) {
 			const acceptable = new Set<string>();
 			for (const comp of expectedTok.components) {

--- a/src/stores/tracking.ts
+++ b/src/stores/tracking.ts
@@ -6,18 +6,11 @@ import { Alg } from "cubing/alg";
 import { cube3x3x3 } from "cubing/puzzles";
 import { createStore } from "solid-js/store";
 import { getInverseMove, getOppositeMove } from "@/lib/legacyMoveHelpers";
-import { mapTokenByZ2 } from "@/lib/orientationMap";
 import { algs } from "@/stores/algs";
 
 // Minimal shape for the kpuzzle object we need (duck-typed)
 interface KPuzzlePatternProvider {
 	defaultPattern?: () => PatternLike;
-}
-
-declare global {
-	interface Window {
-		_orientationMode?: string;
-	}
 }
 
 interface PatternLike {
@@ -65,6 +58,29 @@ interface DoubleBuffer {
 	face: string;
 	first: string;
 	wantsPrime: boolean;
+}
+
+function inferSliceQuarterTurn(
+	axis: "M" | "E" | "S",
+	firstMove: string,
+	secondMove: string,
+): string | null {
+	const first = firstMove.replace(/[()]/g, "");
+	const second = secondMove.replace(/[()]/g, "");
+	const slicePairs: Record<
+		"M" | "E" | "S",
+		{ plain: [string, string]; prime: [string, string] }
+	> = {
+		M: { plain: ["R", "L'"], prime: ["R'", "L"] },
+		E: { plain: ["U'", "D"], prime: ["U", "D'"] },
+		S: { plain: ["F", "B'"], prime: ["F'", "B"] },
+	};
+	const matchesPair = ([a, b]: [string, string]) =>
+		(first === a && second === b) || (first === b && second === a);
+	const pairs = slicePairs[axis];
+	if (matchesPair(pairs.plain)) return axis;
+	if (matchesPair(pairs.prime)) return `${axis}'`;
+	return null;
 }
 
 // ---- Module-level non-reactive heavy objects (equivalent to markRaw in Vue) ----
@@ -172,6 +188,7 @@ export function resetTracking() {
 }
 
 export function setAlgorithm(raw: string) {
+	_didEarlyCalibration = false;
 	const { expanded, grouped } = parseTokens(raw);
 	const canonical = expanded.map(buildCanonical);
 	const map: (string | null)[] = [];
@@ -195,7 +212,12 @@ export function setAlgorithm(raw: string) {
 	setTracking("segments", parseSegments(raw, expanded.length));
 	setTracking("pendingMoves", []);
 	setTracking("patternInitStartedAt", Date.now());
+	// Reset ready so ensureImmediateReady recomputes pattern states for the
+	// new algorithm below (avoids stale _progressPatternRaw / _patternStates
+	// from the previous algorithm if initPatterns hasn't resolved yet).
+	setTracking("ready", false);
 	ensureImmediateReady();
+	advancePastRotations();
 	void initPatterns();
 	setTimeout(() => {
 		if (!tracking.ready && tracking.userAlg === expanded) {
@@ -292,7 +314,21 @@ function forceReady() {
 	}
 }
 
-export function ingestMove(deviceMove: string) {
+// Auto-advance past any rotation tokens (x/y/z) immediately after
+// accepting a move, since physical GAN cubes have no gyroscope and the
+// user never needs to "perform" a rotation token.
+function advancePastRotations() {
+	while (true) {
+		const nextIdx = tracking.currentMoveIndex + 1;
+		const next = tracking.userAlg[nextIdx];
+		if (!next) break;
+		if (!/^[xyz]['2]?$/i.test(next.replace(/[()]/g, ""))) break;
+		_progressPatternRaw = _patternStates[nextIdx] ?? _progressPatternRaw;
+		setTracking("currentMoveIndex", nextIdx);
+	}
+}
+
+export function ingestMove(move: string) {
 	if (!tracking.ready || !tracking.userAlg.length) {
 		if (tracking.userAlg.length && tracking.patternsReadyMode === "none") {
 			debug("autoEnsureReady");
@@ -301,8 +337,8 @@ export function ingestMove(deviceMove: string) {
 		if (tracking.ready) {
 			// continue
 		} else {
-			setTracking("pendingMoves", [...tracking.pendingMoves, deviceMove]);
-			debug("queue:not-ready", { ready: tracking.ready, deviceMove });
+			setTracking("pendingMoves", [...tracking.pendingMoves, move]);
+			debug("queue:not-ready", { ready: tracking.ready, move });
 			return;
 		}
 	}
@@ -315,11 +351,9 @@ export function ingestMove(deviceMove: string) {
 		return;
 	}
 	const norm = (m: string) => m.replace(/[()]/g, "");
-	let logical = deviceMove.trim();
+	let logical = move.trim();
 	if (tracking.eventTransform)
 		logical = applyRotationToMove(logical, tracking.eventTransform);
-	const orientationMode = window._orientationMode || "white-up";
-	if (orientationMode === "yellow-up") logical = mapTokenByZ2(logical);
 	logical = norm(logical);
 
 	if (
@@ -358,8 +392,7 @@ export function ingestMove(deviceMove: string) {
 			if (!acceptable.has(logicalLetter)) {
 				for (const cand of rotationCandidates()) {
 					if (!cand) continue;
-					let rotated = applyRotationToMove(deviceMove, cand);
-					if (orientationMode === "yellow-up") rotated = mapTokenByZ2(rotated);
+					let rotated = applyRotationToMove(move, cand);
 					rotated = norm(rotated);
 					const rLetter = rotated.charAt(0).toUpperCase();
 					if (acceptable.has(rLetter)) {
@@ -416,8 +449,9 @@ export function ingestMove(deviceMove: string) {
 						setTracking("pendingSlice", null);
 						setTracking("acceptedDeviceMoves", [
 							...tracking.acceptedDeviceMoves,
-							deviceMove,
+							move,
 						]);
+						advancePastRotations();
 						recomputeDisplay();
 						return;
 					}
@@ -425,22 +459,16 @@ export function ingestMove(deviceMove: string) {
 			}
 			const firstTok = tracking.pendingSlice.first.replace(/[()]/g, "");
 			const secondTok = logical.replace(/[()]/g, "");
-			const face1 = firstTok[0];
-			const face2 = secondTok[0];
 			const dir = (mv: string) =>
 				mv.endsWith("'") ? -1 : mv.endsWith("2") ? 2 : 1;
 			const d1 = dir(firstTok);
 			const d2 = dir(secondTok);
 			let inferred = false;
 			if (firstTok && Math.abs(d1) === 1 && Math.abs(d2) === 1 && d1 === -d2) {
-				const checkPair = (a: string, b: string, A: string, B: string) =>
-					(a === A && b === B) || (a === B && b === A);
-				if (axis === "M" && checkPair(face1 ?? "", face2 ?? "", "R", "L"))
-					inferred = true;
-				else if (axis === "E" && checkPair(face1 ?? "", face2 ?? "", "U", "D"))
-					inferred = true;
-				else if (axis === "S" && checkPair(face1 ?? "", face2 ?? "", "F", "B"))
-					inferred = true;
+				const inferredSlice = inferSliceQuarterTurn(axis, firstTok, secondTok);
+				inferred = isDoubleSlice
+					? inferredSlice !== null
+					: inferredSlice === normalizedExpect;
 			}
 			if (inferred) {
 				if (isDoubleSlice) {
@@ -462,8 +490,9 @@ export function ingestMove(deviceMove: string) {
 						setTracking("pendingSlice", null);
 						setTracking("acceptedDeviceMoves", [
 							...tracking.acceptedDeviceMoves,
-							deviceMove,
+							move,
 						]);
+						advancePastRotations();
 						recomputeDisplay();
 						return;
 					}
@@ -477,8 +506,9 @@ export function ingestMove(deviceMove: string) {
 					setTracking("pendingSlice", null);
 					setTracking("acceptedDeviceMoves", [
 						...tracking.acceptedDeviceMoves,
-						deviceMove,
+						move,
 					]);
+					advancePastRotations();
 					recomputeDisplay();
 					return;
 				}
@@ -536,8 +566,9 @@ export function ingestMove(deviceMove: string) {
 					setTracking("badAlg", []);
 					setTracking("acceptedDeviceMoves", [
 						...tracking.acceptedDeviceMoves,
-						deviceMove,
+						move,
 					]);
+					advancePastRotations();
 					recomputeDisplay();
 					return;
 				}
@@ -568,8 +599,9 @@ export function ingestMove(deviceMove: string) {
 					setTracking("pendingWide", null);
 					setTracking("acceptedDeviceMoves", [
 						...tracking.acceptedDeviceMoves,
-						deviceMove,
+						move,
 					]);
+					advancePastRotations();
 					recomputeDisplay();
 					return;
 				}
@@ -605,8 +637,9 @@ export function ingestMove(deviceMove: string) {
 				setTracking("pendingDouble", null);
 				setTracking("acceptedDeviceMoves", [
 					...tracking.acceptedDeviceMoves,
-					deviceMove,
+					move,
 				]);
+				advancePastRotations();
 				recomputeDisplay();
 				return;
 			}
@@ -640,8 +673,9 @@ export function ingestMove(deviceMove: string) {
 		setTracking("badAlg", []);
 		setTracking("acceptedDeviceMoves", [
 			...tracking.acceptedDeviceMoves,
-			deviceMove,
+			move,
 		]);
+		advancePastRotations();
 		recomputeDisplay();
 		return;
 	}
@@ -651,8 +685,7 @@ export function ingestMove(deviceMove: string) {
 	if (!tracking.eventTransform) {
 		for (const cand of rotationCandidates()) {
 			if (!cand) continue;
-			let test = applyRotationToMove(deviceMove, cand);
-			if (orientationMode === "yellow-up") test = mapTokenByZ2(test);
+			let test = applyRotationToMove(move, cand);
 			test = norm(test);
 			const testApplied = basePattern.applyMove(test) as PatternLike;
 			if (expectedPattern?.isIdentical?.(testApplied)) {
@@ -662,8 +695,9 @@ export function ingestMove(deviceMove: string) {
 				setTracking("badAlg", []);
 				setTracking("acceptedDeviceMoves", [
 					...tracking.acceptedDeviceMoves,
-					deviceMove,
+					move,
 				]);
+				advancePastRotations();
 				recomputeDisplay();
 				return;
 			}
@@ -680,8 +714,7 @@ export function ingestMove(deviceMove: string) {
 		const basePatternRef = _progressPatternRaw || _currentPattern;
 		for (const r of refine) {
 			const combo = `${tracking.eventTransform} ${r}`.trim();
-			let test = applyRotationToMove(deviceMove, combo);
-			if (orientationMode === "yellow-up") test = mapTokenByZ2(test);
+			let test = applyRotationToMove(move, combo);
 			test = norm(test);
 			const testApplied = (basePatternRef as PatternLike).applyMove(
 				test,
@@ -693,8 +726,9 @@ export function ingestMove(deviceMove: string) {
 				setTracking("badAlg", []);
 				setTracking("acceptedDeviceMoves", [
 					...tracking.acceptedDeviceMoves,
-					deviceMove,
+					move,
 				]);
+				advancePastRotations();
 				recomputeDisplay();
 				return;
 			}
@@ -723,8 +757,7 @@ export function ingestMove(deviceMove: string) {
 		const [outer, sliceComp] = ctok.components;
 		if (outer && sliceComp) {
 			for (const cand of rotationCandidates()) {
-				let rotated = applyRotationToMove(deviceMove, cand);
-				if (orientationMode === "yellow-up") rotated = mapTokenByZ2(rotated);
+				let rotated = applyRotationToMove(move, cand);
 				rotated = norm(rotated);
 				if (rotated === outer || rotated === sliceComp) {
 					const partner = rotated === outer ? sliceComp : outer;
@@ -738,8 +771,9 @@ export function ingestMove(deviceMove: string) {
 						setTracking("badAlg", []);
 						setTracking("acceptedDeviceMoves", [
 							...tracking.acceptedDeviceMoves,
-							deviceMove,
+							move,
 						]);
+						advancePastRotations();
 						recomputeDisplay();
 						return;
 					}

--- a/src/stores/tracking.ts
+++ b/src/stores/tracking.ts
@@ -616,12 +616,18 @@ export function ingestMove(move: string) {
 
 	// Double turn as two quarter turns
 	const expectedIsDouble = /^[URFDLB]2'?$/i.test(expectNorm);
+	let wrongDirectionQuarterOnExpectedDouble = false;
 	if (expectedIsDouble) {
 		const face = expectNorm[0]?.toUpperCase() ?? "";
 		const wantsPrime = expectNorm.endsWith("'");
 		const quarterOk = (mv: string) =>
 			mv[0]?.toUpperCase() === face &&
 			(wantsPrime ? mv.endsWith("'") : !mv.endsWith("'"));
+		wrongDirectionQuarterOnExpectedDouble =
+			logical[0]?.toUpperCase() === face &&
+			/^[URFDLB]['2]?$/.test(logical) &&
+			!logical.endsWith("2") &&
+			!quarterOk(logical);
 		if (!tracking.pendingDouble && quarterOk(logical)) {
 			setTracking("pendingDouble", { face, first: logical, wantsPrime });
 			recomputeDisplay();
@@ -784,7 +790,11 @@ export function ingestMove(move: string) {
 
 	// Record mistake
 	const bad = [...tracking.badAlg];
-	if (bad[bad.length - 1] !== logical) bad.push(logical);
+	if (
+		bad[bad.length - 1] !== logical ||
+		wrongDirectionQuarterOnExpectedDouble
+	)
+		bad.push(logical);
 	if (bad.length > 4) bad.splice(0, bad.length - 4);
 	setTracking("badAlg", bad);
 	recomputeDisplay();

--- a/src/views/PracticeView.tsx
+++ b/src/views/PracticeView.tsx
@@ -33,6 +33,7 @@ import {
 	goNext,
 	goPrev,
 	practice,
+	resetRun,
 	startPractice,
 	stopPractice,
 	visit,
@@ -73,12 +74,22 @@ export default function PracticeView() {
 	const [trainNonce, setTrainNonce] = createSignal(0);
 	const [_auf, setAuf] = createSignal("");
 	const [runningMs, setRunningMs] = createSignal(0);
+	let lastAufCaseId: string | null = null;
 	let ticker: ReturnType<typeof setInterval> | null = null;
 
 	const baseAlg = createMemo(() => {
 		const id = practice.currentId;
 		if (!id) return "";
 		return (algs.cases[id]?.alg ?? "").trim();
+	});
+
+	// Prepend AUF prefix to the base algorithm when randomAUF is enabled.
+	// This memo is the canonical algorithm used for both tracking and CubeViewer.
+	const aufAlg = createMemo(() => {
+		const auf = _auf();
+		const base = baseAlg();
+		if (!auf || !algs.options.randomAUF) return base;
+		return `${auf} ${base}`.trim();
 	});
 
 	const emptyState = createMemo(
@@ -93,6 +104,18 @@ export default function PracticeView() {
 	const showGradeBar = createMemo(
 		() => practice.orderMode === "fsrs" && !!practice.currentId,
 	);
+
+	const isSolved = createMemo(
+		() =>
+			tracking.userAlg.length > 0 &&
+			tracking.badAlg.length === 0 &&
+			tracking.currentMoveIndex >= tracking.userAlg.length - 1,
+	);
+
+	const timerDisplay = createMemo(() => {
+		if (practice.running) return `${(runningMs() / 1000).toFixed(2)}s`;
+		return tracking.currentMoveIndex === -1 ? "0.00s" : lastMsDisplay();
+	});
 
 	function pickNextId(): string | null {
 		if (practice.orderMode === "fsrs") {
@@ -166,16 +189,10 @@ export default function PracticeView() {
 	}
 
 	function train() {
-		if (!practice.running) {
-			if (algs.options.randomAUF) setAuf(pickRandomAuf());
-			startPractice();
-			setTrainNonce((n) => n + 1);
-		} else {
-			stopPractice();
-			if (algs.options.randomAUF) setAuf(pickRandomAuf());
-			setTrainNonce((n) => n + 1);
-		}
+		setTrainNonce((n) => n + 1);
 		resetTracking();
+		resetRun();
+		setRunningMs(0);
 	}
 
 	function editCurrent() {
@@ -209,20 +226,52 @@ export default function PracticeView() {
 		if (moveAt == null) return;
 		if (!mv) return;
 		untrack(() => {
+			if (!practice.running && practice.currentId && !isSolved()) {
+				setRunningMs(0);
+				startPractice();
+			}
+			// Single translation point: hardware move → logical move (z2 for yellow-up)
 			const logical =
 				orientationMode() === "yellow-up" ? mapTokenByZ2(mv.trim()) : mv.trim();
 			ingestMove(logical);
 		});
 	});
 
-	// Keep tracking algorithm in sync when case changes
 	createEffect(() => {
-		const alg = baseAlg();
+		if (!practice.running) return;
+		if (!isSolved()) return;
+		untrack(() => stopPractice());
+	});
+
+	// Keep tracking algorithm in sync when case changes (including AUF prefix)
+	createEffect(() => {
+		const alg = aufAlg();
 		if (!alg) return;
 		// This effect also handles the initial mount. Re-applying the same algorithm
 		// after a move would reset tracking back to the first letter.
 		if (alg === untrack(() => tracking.rawAlg)) return;
 		setAlgorithm(alg);
+	});
+
+	createEffect(() => {
+		const currentId = practice.currentId;
+		const randomAufEnabled = algs.options.randomAUF;
+
+		if (!currentId) {
+			lastAufCaseId = null;
+			if (_auf()) setAuf("");
+			return;
+		}
+
+		if (!randomAufEnabled) {
+			lastAufCaseId = null;
+			if (_auf()) setAuf("");
+			return;
+		}
+
+		if (lastAufCaseId === currentId) return;
+		lastAufCaseId = currentId;
+		setAuf(pickRandomAuf());
 	});
 
 	createEffect(() => {
@@ -277,16 +326,14 @@ export default function PracticeView() {
 				</div>
 
 				<div class="flex flex-col items-center">
-					<CubeViewer alg={baseAlg()} trainNonce={trainNonce()} />
+					<CubeViewer alg={aufAlg()} trainNonce={trainNonce()} />
 					<Show when={emptyState()}>
 						<div class="mt-2 text-sm text-gray-500">No Cases Scheduled</div>
 					</Show>
 				</div>
 
 				<div class="text-4xl font-mono tabular-nums text-center">
-					<Show when={practice.running} fallback={<div>{lastMsDisplay()}</div>}>
-						<div>{(runningMs() / 1000).toFixed(2)}s</div>
-					</Show>
+					<div>{timerDisplay()}</div>
 				</div>
 			</div>
 

--- a/src/views/PracticeView.tsx
+++ b/src/views/PracticeView.tsx
@@ -231,6 +231,15 @@ export default function PracticeView() {
 				startPractice();
 			}
 			// Single translation point: hardware move → logical move (z2 for yellow-up)
+			// 1. src/services/ganBluetooth.ts receives `MOVE` events from
+			//    `gan-web-bluetooth` and emits `{ type: "move", move }`.
+			// 2. src/stores/device.ts subscribes via `onGanEvents(...)` and
+			//    writes `device.lastMove` plus `device.lastMoveAt`.
+			// 3. src/views/PracticeView.tsx reacts to that store edge and does
+			//    the logical translation before calling `ingestMove(...)`.
+			// 4. src/components/practice/CubeViewer.tsx separately reacts to
+			//    the same raw store edge for display and applies the same z2
+			//    mapping for `experimentalAddMove(...)`.
 			const logical =
 				orientationMode() === "yellow-up" ? mapTokenByZ2(mv.trim()) : mv.trim();
 			ingestMove(logical);

--- a/tests/stores/tracking.test.ts
+++ b/tests/stores/tracking.test.ts
@@ -177,6 +177,23 @@ describe("ingestMove – double turns", () => {
 		// Move is buffered, not yet accepted at the expected index
 		expect(tracking.currentMoveIndex).toBe(-1);
 	});
+
+	it("requires two opposite quarter turns to undo a wrong-direction double turn", () => {
+		loadAlg("U2 R");
+
+		ingestMove("U'");
+		ingestMove("U'");
+		expect(tracking.badAlg).toEqual(["U'", "U'"]);
+		expect(tracking.currentMoveIndex).toBe(-1);
+
+		ingestMove("U");
+		expect(tracking.badAlg).toEqual(["U'"]);
+		expect(tracking.currentMoveIndex).toBe(-1);
+
+		ingestMove("U");
+		expect(tracking.badAlg).toHaveLength(0);
+		expect(tracking.currentMoveIndex).toBe(-1);
+	});
 });
 
 describe("ingestMove – slice composites", () => {

--- a/tests/stores/tracking.test.ts
+++ b/tests/stores/tracking.test.ts
@@ -109,6 +109,16 @@ describe("resetTracking", () => {
 		expect(tracking.currentMoveIndex).toBe(-1);
 		expect(tracking.badAlg).toHaveLength(0);
 	});
+
+	it("still skips leading rotations after reset before accepting a move", () => {
+		loadAlg("y R U");
+		resetTracking();
+
+		ingestMove("R");
+
+		expect(tracking.currentMoveIndex).toBe(1);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
 });
 
 describe("ingestMove – white-up orientation", () => {

--- a/tests/stores/tracking.test.ts
+++ b/tests/stores/tracking.test.ts
@@ -1,0 +1,240 @@
+/**
+ * tests/stores/tracking.test.ts
+ *
+ * Unit tests for the `tracking` store: `setAlgorithm`, `resetTracking`, and
+ * `ingestMove`.
+ *
+ * `tracking.ts` uses cubing/alg for simplified bad-alg display and
+ * cubing/puzzles for kpuzzle-based pattern verification.  Both are mocked:
+ * - cubing/alg: `Alg.fromString()` returns a trivial object whose
+ *   `experimentalSimplify()` echoes the input (sufficient for bad-alg tests).
+ * - cubing/puzzles: `cube3x3x3.kpuzzle()` rejects, forcing the store to use
+ *   its built-in SeqPattern fallback indefinitely. This makes tests
+ *   deterministic and avoids async pattern-state overwrite races.
+ *
+ * State is reset between tests via `setAlgorithm` (or `resetTracking`), which
+ * clears all in-flight move buffers and pending-moves queues.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock DB layer (algs store dependency) ─────────────────────────────────────
+vi.mock("@/lib/db/client-sqlite", () => ({
+	getDb: () => null,
+	schema: {},
+	persistDb: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/db/db-state", () => ({
+	getCurrentUserId: () => "test-user-id",
+}));
+
+// ── Mock cubing/alg ───────────────────────────────────────────────────────────
+// experimentalSimplify must be present; it echoes the input so bad-alg state
+// is preserved rather than collapsed to an empty string.
+vi.mock("cubing/alg", () => ({
+	Alg: {
+		fromString(s: string) {
+			return {
+				experimentalSimplify: () => ({ toString: () => s }),
+				toString: () => s,
+			};
+		},
+	},
+}));
+
+// ── Mock cubing/puzzles ───────────────────────────────────────────────────────
+// Reject so `initPatterns` never replaces the SeqPattern fallback state,
+// ensuring all tests use the same deterministic in-memory pattern comparison.
+vi.mock("cubing/puzzles", () => ({
+	cube3x3x3: {
+		kpuzzle: () => Promise.reject(new Error("mock: kpuzzle not available")),
+	},
+}));
+
+// ── Import store after mocks ──────────────────────────────────────────────────
+import {
+	ingestMove,
+	resetTracking,
+	setAlgorithm,
+	tracking,
+} from "@/stores/tracking";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Reset tracking before each test by loading a fresh algorithm. */
+function loadAlg(alg: string) {
+	setAlgorithm(alg);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("setAlgorithm", () => {
+	it("resets state to initial conditions", () => {
+		loadAlg("R U R'");
+		// Partially advance the algorithm
+		ingestMove("R");
+		expect(tracking.currentMoveIndex).toBe(0);
+
+		// Re-loading the same algorithm resets everything
+		loadAlg("R U R'");
+		expect(tracking.currentMoveIndex).toBe(-1);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+
+	it("parses the algorithm into userAlg tokens", () => {
+		loadAlg("R U R'");
+		expect(tracking.userAlg).toEqual(["R", "U", "R'"]);
+	});
+
+	it("auto-advances past a leading rotation token", () => {
+		// When the first token is a rotation (y), it should be skipped
+		loadAlg("y R U R'");
+		// y is auto-advanced; currentMoveIndex should point past it
+		expect(tracking.currentMoveIndex).toBe(0);
+		expect(tracking.userAlg[1]).toBe("R");
+	});
+});
+
+describe("resetTracking", () => {
+	it("clears move index and errors mid-algorithm", () => {
+		loadAlg("R U R'");
+		// R' is a wrong-direction move that rotation calibration cannot rescue
+		// (same letter as R, so calibration accepts the letter match, but
+		// R' ≠ R in the pattern comparison, so the move is recorded as an error).
+		ingestMove("R'");
+		expect(tracking.badAlg).not.toHaveLength(0);
+
+		resetTracking();
+		expect(tracking.currentMoveIndex).toBe(-1);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+});
+
+describe("ingestMove – white-up orientation", () => {
+	beforeEach(() => {
+		loadAlg("R U R'");
+	});
+
+	it("accepts the first correct move and advances index", () => {
+		ingestMove("R");
+		expect(tracking.currentMoveIndex).toBe(0);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+
+	it("steps through a full sequence successfully", () => {
+		ingestMove("R");
+		ingestMove("U");
+		ingestMove("R'");
+		expect(tracking.currentMoveIndex).toBe(2);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+
+	it("records a wrong move as badAlg", () => {
+		// R' (primed) when R (unprimed) is expected: rotation calibration cannot
+		// rescue this because all rotations preserve the prime suffix, so no
+		// rotated R' can equal the expected pattern SeqPattern(["R"]).
+		ingestMove("R'");
+		expect(tracking.badAlg).not.toHaveLength(0);
+	});
+
+	it("undoes the last wrong move when its inverse is sent", () => {
+		ingestMove("R'"); // wrong direction
+		expect(tracking.badAlg).not.toHaveLength(0);
+
+		ingestMove("R"); // inverse of R' undoes it
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+});
+
+describe("ingestMove – yellow-up orientation", () => {
+	it("accepts U (logical) mapped from hardware D in yellow-up mode", () => {
+		loadAlg("U R U'");
+		// In yellow-up, PracticeView pre-translates: hardware D → logical U
+		ingestMove("U");
+		expect(tracking.currentMoveIndex).toBe(0);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+
+	it("full sequence accepted with pre-translated moves", () => {
+		loadAlg("U R");
+		ingestMove("U"); // pre-translated from hardware D
+		ingestMove("R"); // pre-translated from hardware L
+		expect(tracking.currentMoveIndex).toBe(1);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+});
+
+describe("ingestMove – double turns", () => {
+	it("buffers the first quarter turn into pendingDouble", () => {
+		// The full U2-acceptance path requires kpuzzle's mathematical equivalence
+		// (U*U = U2 in group theory), which SeqPattern cannot verify.
+		// We test the buffering mechanism: one U puts the move in pendingDouble.
+		loadAlg("U2 R");
+		ingestMove("U");
+		expect(tracking.pendingDouble).not.toBeNull();
+		expect(tracking.pendingDouble?.face).toBe("U");
+		// Move is buffered, not yet accepted at the expected index
+		expect(tracking.currentMoveIndex).toBe(-1);
+	});
+});
+
+describe("ingestMove – slice composites", () => {
+	it("accepts M from the correct R + L' composite", () => {
+		loadAlg("M U");
+		ingestMove("R");
+		ingestMove("L'");
+		expect(tracking.currentMoveIndex).toBe(0);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+
+	it("rejects the wrong-direction R' + L composite when M is expected", () => {
+		loadAlg("M U");
+		ingestMove("R'");
+		ingestMove("L");
+		expect(tracking.currentMoveIndex).toBe(-1);
+		expect(tracking.badAlg).not.toHaveLength(0);
+	});
+});
+
+describe("ingestMove – rotation auto-advance", () => {
+	it("auto-advances past an inline rotation token", () => {
+		loadAlg("R y R'");
+		ingestMove("R");
+		// After accepting R, the y token should be auto-skipped
+		// currentMoveIndex should now be 1 (past y), so R' is next
+		expect(tracking.currentMoveIndex).toBe(1);
+	});
+
+	it("accepts the move after an auto-advanced rotation", () => {
+		loadAlg("R y R'");
+		ingestMove("R");
+		ingestMove("R'");
+		expect(tracking.currentMoveIndex).toBe(2);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+
+	it("auto-advances past consecutive rotations", () => {
+		loadAlg("R y x R'");
+		ingestMove("R");
+		// Both y and x should be skipped automatically
+		expect(tracking.currentMoveIndex).toBe(2); // past R(0), y(1), x(2)
+	});
+});
+
+describe("ingestMove – AUF prefix tracking", () => {
+	it("accepts U as the AUF move at the start of the alg", () => {
+		loadAlg("U R U'"); // U is the AUF, R U' is the base
+		ingestMove("U");
+		expect(tracking.currentMoveIndex).toBe(0);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+
+	it("accepts U (pre-translated from hardware D in yellow-up) as AUF U", () => {
+		loadAlg("U R U'");
+		// PracticeView translates hardware D → logical U before calling ingestMove
+		ingestMove("U");
+		expect(tracking.currentMoveIndex).toBe(0);
+		expect(tracking.badAlg).toHaveLength(0);
+	});
+});

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -16,7 +16,7 @@
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20240529.0",
 				"typescript": "~5.9.3",
-				"wrangler": "^4.52.1"
+				"wrangler": "^4.78.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -30,9 +30,9 @@
 			}
 		},
 		"node_modules/@cloudflare/unenv-preset": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
-			"integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+			"integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"peerDependencies": {
@@ -46,9 +46,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260312.1.tgz",
-			"integrity": "sha512-HUAtDWaqUduS6yasV6+NgsK7qBpP1qGU49ow/Wb117IHjYp+PZPUGReDYocpB4GOMRoQlvdd4L487iFxzdARpw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
+			"integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
 			"cpu": [
 				"x64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260312.1.tgz",
-			"integrity": "sha512-DOn7TPTHSxJYfi4m4NYga/j32wOTqvJf/pY4Txz5SDKWIZHSTXFyGz2K4B+thoPWLop/KZxGoyTv7db0mk/qyw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
+			"integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -80,9 +80,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260312.1.tgz",
-			"integrity": "sha512-TdkIh3WzPXYHuvz7phAtFEEvAxvFd30tHrm4gsgpw0R0F5b8PtoM3hfL2uY7EcBBWVYUBtkY2ahDYFfufnXw/g==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
+			"integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
 			"cpu": [
 				"x64"
 			],
@@ -97,9 +97,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260312.1.tgz",
-			"integrity": "sha512-kNauZhL569Iy94t844OMwa1zP6zKFiL3xiJ4tGLS+TFTEfZ3pZsRH6lWWOtkXkjTyCmBEOog0HSEKjIV4oAffw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
+			"integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
 			"cpu": [
 				"arm64"
 			],
@@ -114,9 +114,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260312.1.tgz",
-			"integrity": "sha512-5dBrlSK+nMsZy5bYQpj8t9iiQNvCRlkm9GGvswJa9vVU/1BNO4BhJMlqOLWT24EmFyApZ+kaBiPJMV8847NDTg==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
+			"integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
 			"cpu": [
 				"x64"
 			],
@@ -131,9 +131,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260313.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260313.1.tgz",
-			"integrity": "sha512-jMEeX3RKfOSVqqXRKr/ulgglcTloeMzSH3FdzIfqJHtvc12/ELKd5Ldsg8ZHahKX/4eRxYdw3kbzb8jLXbq/jQ==",
+			"version": "4.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260317.1.tgz",
+			"integrity": "sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==",
 			"devOptional": true,
 			"license": "MIT OR Apache-2.0"
 		},
@@ -151,9 +151,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+			"integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1164,9 +1164,9 @@
 			}
 		},
 		"node_modules/@speed-highlight/core": {
-			"version": "1.2.14",
-			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
-			"integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+			"version": "1.2.15",
+			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+			"integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -1412,6 +1412,27 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/miniflare": {
+			"version": "4.20260317.3",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.3.tgz",
+			"integrity": "sha512-tK78D3X4q30/SXqVwMhWrUfH+ffRou9dJLC+jkhNy5zh1I7i7T4JH6xihOvYxdCSBavJ5fQXaaxDJz6orh09BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
+				"sharp": "^0.34.5",
+				"undici": "7.24.4",
+				"workerd": "1.20260317.1",
+				"ws": "8.18.0",
+				"youch": "4.1.0-beta.10"
+			},
+			"bin": {
+				"miniflare": "bootstrap.js"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/oosync": {
 			"version": "0.1.0",
 			"resolved": "git+ssh://git@github.com/sboagy/oosync.git#aceff8724d79e6e4eee44a74e984c0270f3493d4",
@@ -1549,9 +1570,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-			"integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+			"integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1569,9 +1590,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260312.1.tgz",
-			"integrity": "sha512-nNpPkw9jaqo79B+iBCOiksx+N62xC+ETIfyzofUEdY3cSOHJg6oNnVSHm7vHevzVblfV76c8Gr0cXHEapYMBEg==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
+			"integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -1582,67 +1603,46 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260312.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260312.1",
-				"@cloudflare/workerd-linux-64": "1.20260312.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260312.1",
-				"@cloudflare/workerd-windows-64": "1.20260312.1"
+				"@cloudflare/workerd-darwin-64": "1.20260317.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260317.1",
+				"@cloudflare/workerd-linux-64": "1.20260317.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260317.1",
+				"@cloudflare/workerd-windows-64": "1.20260317.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.73.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.73.0.tgz",
-			"integrity": "sha512-VJXsqKDFCp6OtFEHXITSOR5kh95JOknwPY8m7RyQuWJQguSybJy43m4vhoCSt42prutTef7eeuw7L4V4xiynGw==",
+			"version": "4.78.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.78.0.tgz",
+			"integrity": "sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.4.2",
-				"@cloudflare/unenv-preset": "2.15.0",
+				"@cloudflare/unenv-preset": "2.16.0",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260312.0",
+				"miniflare": "4.20260317.3",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260312.1"
+				"workerd": "1.20260317.1"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=20.3.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260312.1"
+				"@cloudflare/workers-types": "^4.20260317.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/wrangler/node_modules/miniflare": {
-			"version": "4.20260312.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260312.0.tgz",
-			"integrity": "sha512-pieP2rfXynPT6VRINYaiHe/tfMJ4c5OIhqRlIdLF6iZ9g5xgpEmvimvIgMpgAdDJuFlrLcwDUi8MfAo2R6dt/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cspotcode/source-map-support": "0.8.1",
-				"sharp": "^0.34.5",
-				"undici": "7.18.2",
-				"workerd": "1.20260312.1",
-				"ws": "8.18.0",
-				"youch": "4.1.0-beta.10"
-			},
-			"bin": {
-				"miniflare": "bootstrap.js"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/ws": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20240529.0",
 		"typescript": "~5.9.3",
-		"wrangler": "^4.52.1"
+		"wrangler": "^4.78.0"
 	},
 	"dependencies": {
 		"oosync": "git+https://github.com/sboagy/oosync.git#main",


### PR DESCRIPTION
## Summary
- refactor practice move tracking to ingest logical moves only and tighten reset/timer behavior
- add tracking regressions for slice and double-turn mistake handling
- harden offline device-mode E2E readiness checks and document the move translation flow
- update worker tooling dependencies included on this branch

## Validation
- npm run typecheck
- unit test suite passed earlier in this branch during implementation
- editor diagnostics clean for the final comment-only change

Fixes https://github.com/sboagy/cubefsrs/issues/6 .