### PR TITLE
 🐛 fix(ci): use resolvable CubeFSRS staging Pages URL

### DIFF
--- a/.env.staging.template
+++ b/.env.staging.template
@@ -19,7 +19,7 @@ PYTHONPATH=.
 GITHUB_REPO=cubefsrs
 
 VITE_WORKER_URL="op://rhizome/shared-staging/Vite/VITE_WORKER_URL_CUBEFSRS"
-STAGING_BASE_URL="op://rhizome/shared-staging/Vite/STAGING_BASE_URL_CUBEFSRS"
+STAGING_BASE_URL="https://staging.cubefsrs-pwa.pages.dev"
 
 GEMINI_API_KEY="op://rhizome/shared-staging/Gemini/GEMINI_API_KEY"
 ALICE_TEST_PASSWORD="op://rhizome/shared-staging/Test/ALICE_TEST_PASSWORD"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,7 +836,7 @@ jobs:
             --method POST \
             -f state="success" \
             -f environment="staging" \
-            -f environment_url="https://staging.cubefsrs.com" \
+            -f environment_url="https://staging.cubefsrs-pwa.pages.dev" \
             -f log_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             -f description="Staging deploy, catalog refresh, and smoke tests passed"
 

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -25,6 +25,7 @@ Staging uses:
 
 - `.env.staging.template`
 - Cloudflare Pages project `cubefsrs-pwa`, branch `staging`
+- Staging app URL `https://staging.cubefsrs-pwa.pages.dev`
 - Worker `cubefsrs-sync-worker-staging`
 - staging Supabase values from `op://rhizome/shared-staging/...`
 - a staging Hyperdrive binding in `worker/wrangler.toml`

--- a/e2e/staging/staging-smoke.spec.ts
+++ b/e2e/staging/staging-smoke.spec.ts
@@ -19,7 +19,7 @@ const normalizePublicUrl = (value: string, name: string): string => {
 };
 
 const STAGING_BASE_URL = normalizePublicUrl(
-	process.env.STAGING_BASE_URL ?? "https://staging.cubefsrs.com",
+	process.env.STAGING_BASE_URL ?? "https://staging.cubefsrs-pwa.pages.dev",
 	"STAGING_BASE_URL",
 );
 const WORKER_URL = normalizePublicUrl(

--- a/playwright.staging.config.ts
+++ b/playwright.staging.config.ts
@@ -2,7 +2,8 @@
 
 import { defineConfig, devices } from "@playwright/test";
 
-const baseURL = process.env.STAGING_BASE_URL ?? "https://staging.cubefsrs.com";
+const baseURL =
+	process.env.STAGING_BASE_URL ?? "https://staging.cubefsrs-pwa.pages.dev";
 
 export default defineConfig({
 	testDir: "./e2e/staging",


### PR DESCRIPTION
Point staging smoke tests and GitHub deployment metadata at the Cloudflare Pages branch alias, https://staging.cubefsrs-pwa.pages.dev, instead of staging.cubefsrs.com.

The custom staging domain currently has no DNS records, causing the staging smoke test to fail in GitHub Actions with ENOTFOUND before it can verify the deployed app shell.

Also document the active staging app URL in the deployment notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging environment configuration to use new application URL
  * Updated staging deployment and testing infrastructure to reference the new environment endpoint
  
* **Documentation**
  * Updated deployment documentation with staging environment details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->